### PR TITLE
[BUGFIX] Treat comments, CDATA and doctypes as atomic

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -4,6 +4,21 @@ namespace PrettyXml;
 
 class Formatter
 {
+    /**
+     * Sections whose content is character data, not markup: comments, CDATA
+     * blocks and doctype declarations (optionally carrying an internal subset).
+     *
+     * Their content must never be split on "<", never be indented and never
+     * have whitespace collapsed. Alternation order does not matter, because the
+     * engine matches whichever section starts first: a "<![CDATA[" inside a
+     * comment is text, and a "<!--" inside a CDATA block is text.
+     */
+    private const ATOMIC_SECTION_PATTERN = '/<!--.*?-->|<!\[CDATA\[.*?\]\]>|<!DOCTYPE[^>\[]*(?:\[.*?\])?[^>]*>/s';
+
+    private const PLACEHOLDER_PREFIX = '<!--PRETTY_XML_ATOMIC_SECTION_';
+
+    private const PLACEHOLDER_SUFFIX = '-->';
+
     private int $indent = 4;
 
     private string $padChar = ' ';
@@ -20,6 +35,8 @@ class Formatter
 
     public function format(string $xml): string
     {
+        [$xml, $atomicSections] = $this->extractAtomicSections($xml);
+
         $lines = $this->splitIntoLines($xml);
         $inComment = false;
         $deep = 0;
@@ -45,14 +62,19 @@ class Formatter
             ) {
                 $str .= $line;
                 if (!$inComment) {
-                    $deep--;
+                    $deep = $this->decreaseDepth($deep);
                 }
             } elseif (preg_match('/<\w/', $line) && !preg_match('/<\//', $line) && !preg_match('/\/>/', $line)) {
                 $str .= !$inComment ? $this->getPaddedString($line, $deep++) : $line;
             } elseif (preg_match('/<\w/', $line) && preg_match('/<\//', $line)) {
                 $str .= !$inComment ? $this->getPaddedString($line, $deep) : $line;
             } elseif (preg_match('/<\//', $line)) {
-                $str .= !$inComment ? $this->getPaddedString($line, --$deep) : $line;
+                if ($inComment) {
+                    $str .= $line;
+                } else {
+                    $deep = $this->decreaseDepth($deep);
+                    $str .= $this->getPaddedString($line, $deep);
+                }
             } elseif (preg_match('/\/>/', $line)) {
                 $str .= !$inComment ? $this->getPaddedString($line, $deep) : $line;
             } elseif (preg_match('/<\?/', $line)) {
@@ -64,7 +86,9 @@ class Formatter
             }
         }
 
-        return (($str[0] ?? '') === "\n") ? substr($str, 1) : $str;
+        $str = (($str[0] ?? '') === "\n") ? substr($str, 1) : $str;
+
+        return $this->restoreAtomicSections($str, $atomicSections);
     }
 
     public function minify(string $xml, bool $preserveComments = false): string
@@ -73,6 +97,10 @@ class Formatter
             $xml = preg_replace('/<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)>/', '', $xml);
             $xml = preg_replace('/[ \r\n\t]+xmlns/', ' xmlns', $xml);
         }
+
+        // Comments that survive must keep their content, and CDATA content is
+        // significant whitespace by definition, so neither may be minified.
+        [$xml, $atomicSections] = $this->extractAtomicSections($xml);
 
         // minify xml declaration
         $xml = preg_replace('/\s*\?>/', '?>', $xml);
@@ -87,7 +115,60 @@ class Formatter
         $xml = preg_replace('/\s*\/>/', '/>', $xml);
 
         // removes spaces before closing tag
-        return preg_replace('/\s*>\s*</', '><', $xml);
+        $xml = preg_replace('/\s*>\s*</', '><', $xml);
+
+        return $this->restoreAtomicSections($xml, $atomicSections);
+    }
+
+    /**
+     * Replaces every atomic section with an inert single-token placeholder, so
+     * that the formatter treats it as one opaque tag instead of parsing its
+     * content as markup.
+     *
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private function extractAtomicSections(string $xml): array
+    {
+        $atomicSections = [];
+
+        $result = preg_replace_callback(
+            self::ATOMIC_SECTION_PATTERN,
+            static function (array $matches) use (&$atomicSections): string {
+                $placeholder = self::PLACEHOLDER_PREFIX . count($atomicSections) . self::PLACEHOLDER_SUFFIX;
+                $atomicSections[$placeholder] = $matches[0];
+
+                return $placeholder;
+            },
+            $xml
+        );
+
+        // A catastrophic backtrack leaves the input untouched rather than empty.
+        if ($result === null) {
+            return [$xml, []];
+        }
+
+        return [$result, $atomicSections];
+    }
+
+    /**
+     * @param array<string, string> $atomicSections
+     */
+    private function restoreAtomicSections(string $xml, array $atomicSections): string
+    {
+        if ($atomicSections === []) {
+            return $xml;
+        }
+
+        return str_replace(array_keys($atomicSections), array_values($atomicSections), $xml);
+    }
+
+    /**
+     * Unbalanced markup must not push the depth below the root level, where it
+     * would otherwise produce a negative padding width.
+     */
+    private function decreaseDepth(int $deep): int
+    {
+        return $deep > 0 ? $deep - 1 : 0;
     }
 
     private function splitIntoLines(string $text): array
@@ -101,6 +182,8 @@ class Formatter
 
     private function getPaddedString(string $string, int $depth): string
     {
-        return "\n" . str_repeat($this->padChar, $depth * $this->indent) . $string;
+        $width = $depth * $this->indent;
+
+        return "\n" . str_repeat($this->padChar, $width > 0 ? $width : 0) . $string;
     }
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -485,6 +485,144 @@ XML;
         self::assertEquals($expected, $this->subject->format($input));
     }
 
+    // Atomic sections: comments, CDATA and doctype declarations
+
+    public function testItDoesNotCrashOnCdataInsideAComment(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example: <![CDATA[<a><b>x</b></a>]]> </b></a> -->
+<root>
+    <item>v</item>
+</root>
+XML;
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example: <![CDATA[<a><b>x</b></a>]]> </b></a> -->
+<root>
+    <item>v</item>
+</root>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
+    public function testItKeepsMarkupInsideACommentIntact(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <!-- <config>
+        <foo>bar</foo>
+    </config> -->
+    <item>v</item>
+</root>
+XML;
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <!-- <config>
+        <foo>bar</foo>
+    </config> -->
+    <item>v</item>
+</root>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
+    public function testItKeepsWhitespaceBetweenTagsInsideCdata(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <item><![CDATA[<config>
+    <foo>bar</foo>
+</config>]]></item>
+</root>
+XML;
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <item>
+        <![CDATA[<config>
+    <foo>bar</foo>
+</config>]]>
+    </item>
+</root>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
+    public function testItDoesNotLeakIndentationAfterACommentContainingMarkup(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <!-- <b>bold</b> and <![CDATA[x]]> -->
+    <first>a</first>
+    <second>b</second>
+</root>
+XML;
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <!-- <b>bold</b> and <![CDATA[x]]> -->
+    <first>a</first>
+    <second>b</second>
+</root>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
+    public function testItKeepsADoctypeWithAnInternalSubsetOnOneLine(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root [<!ENTITY foo "bar"><!ENTITY baz "qux">]>
+<root>
+    <item>v</item>
+</root>
+XML;
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root [<!ENTITY foo "bar"><!ENTITY baz "qux">]>
+<root>
+    <item>v</item>
+</root>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
+    public function testItDoesNotCrashOnUnbalancedMarkup(): void
+    {
+        $input = '<?xml version="1.0" encoding="UTF-8"?><foo></foo></bar></baz>';
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<foo></foo>
+</bar>
+</baz>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
+    public function testItDoesNotTreatCdataContentAsNamespaceDeclarations(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <item><![CDATA[use xmlns:foo="bar" here]]></item>
+</root>
+XML;
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <item>
+        <![CDATA[use xmlns:foo="bar" here]]>
+    </item>
+</root>
+XML;
+        self::assertEquals($expected, $this->subject->format($input));
+    }
+
     // Minify
 
     public function testSimplyMinify(): void
@@ -592,6 +730,24 @@ XML;
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/"><channel><title>Example</title></channel></rss>
 XML;
+        self::assertEquals($expected, $this->subject->minify($input));
+    }
+
+    public function testMinifyKeepsCdataContentIntact(): void
+    {
+        $input = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<foo>
+    <bar><![CDATA[some
+whitespaced   words
+      blah]]></bar>
+</foo>
+XML;
+
+        $expected = '<?xml version="1.0" encoding="UTF-8"?><foo><bar><![CDATA[some' . "\n"
+            . 'whitespaced   words' . "\n"
+            . '      blah]]></bar></foo>';
+
         self::assertEquals($expected, $this->subject->minify($input));
     }
 }


### PR DESCRIPTION
The formatter splits its input on every `<` and classifies each fragment as markup. Comments and CDATA sections get torn apart in that step, which breaks in three ways — the worst being an uncaught `ValueError` from `str_repeat()` when a CDATA section sits inside a comment, because `]]>` contains `]>` and ends the comment state too early.

The commit message has the full breakdown. Short version: comments, CDATA and doctype declarations are character data, so they're now swapped for single-token placeholders before formatting and restored verbatim afterwards. `minify()` had the same problem and shares the fix.

Existing behaviour is unchanged — all 29 existing tests pass untouched, plus 8 new ones covering the crash, the whitespace loss inside CDATA, the indentation leak and doctype internal subsets.

Found downstream in FriendsOfTYPO3/fractor#435, where this crashes Fractor on valid XML.